### PR TITLE
Add RSS feed

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
-  site: 'https://twistinside.com',
+  site: 'https://twistinsi.de',
   integrations: [ mdx() ],
   markdown: {
     syntaxHighlight: false,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
 
 export default defineConfig({
+  site: 'https://twistinside.com',
   integrations: [ mdx() ],
   markdown: {
     syntaxHighlight: false,

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,7 +10,8 @@ const { title = "Twistinside" } = Astro.props;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
-    
+    <link rel="alternate" type="application/rss+xml" title="Twistinside RSS Feed" href="/rss.xml" />
+
     <!-- Preload critical assets -->
     <link rel="preload" href="/fonts/nightingale.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/sentient-light.woff2" as="font" type="font/woff2" crossorigin />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,36 @@
+import { getCollection } from 'astro:content';
+
+export async function GET(context) {
+  const site = context.site ?? 'https://twistinside.com';
+  const articles = await getCollection('articles');
+  const items = articles
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+    .map((article) => {
+      const url = new URL(`/articles/${article.slug}/`, site);
+      return `    <item>\n` +
+        `      <title><![CDATA[${article.data.title}]]></title>\n` +
+        `      <description><![CDATA[${article.data.description}]]></description>\n` +
+        `      <link>${url}</link>\n` +
+        `      <guid>${url}</guid>\n` +
+        `      <pubDate>${article.data.date.toUTCString()}</pubDate>\n` +
+        `    </item>`;
+    })
+    .join("\n");
+
+  const rss = `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<rss version="2.0">\n` +
+    `  <channel>\n` +
+    `    <title>Twistinside</title>\n` +
+    `    <description>Latest articles from Twistinside</description>\n` +
+    `    <link>${site}</link>\n` +
+    `    ${items}\n` +
+    `  </channel>\n` +
+    `</rss>`;
+
+  return new Response(rss, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  });
+}
+


### PR DESCRIPTION
## Summary
- configure site URL for RSS
- expose RSS feed listing articles
- link to RSS feed in global layout

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b611747c2c832b88399a941fb52629