### PR TITLE
Serve full article content in RSS feed

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,29 +1,41 @@
 import { getCollection } from 'astro:content';
+import { experimental_AstroContainer } from 'astro/container';
+import mdxRenderer from '@astrojs/mdx/server.js';
 
 export async function GET(context) {
   const site = context.site ?? 'https://twistinside.com';
   const articles = await getCollection('articles');
-  const items = articles
-    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
-    .map((article) => {
-      const url = new URL(`/articles/${article.slug}/`, site);
-      return `    <item>\n` +
-        `      <title><![CDATA[${article.data.title}]]></title>\n` +
-        `      <description><![CDATA[${article.data.description}]]></description>\n` +
-        `      <link>${url}</link>\n` +
-        `      <guid>${url}</guid>\n` +
-        `      <pubDate>${article.data.date.toUTCString()}</pubDate>\n` +
-        `    </item>`;
-    })
-    .join("\n");
+
+  const container = await experimental_AstroContainer.create();
+  container.addServerRenderer({ renderer: mdxRenderer });
+
+  const items = await Promise.all(
+    articles
+      .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
+      .map(async (article) => {
+        const url = new URL(`/articles/${article.slug}/`, site);
+
+        const { Content } = await article.render();
+        const html = await container.renderToString(Content);
+
+        return `    <item>\n` +
+          `      <title><![CDATA[${article.data.title}]]></title>\n` +
+          `      <description><![CDATA[${article.data.description}]]></description>\n` +
+          `      <link>${url}</link>\n` +
+          `      <guid>${url}</guid>\n` +
+          `      <pubDate>${article.data.date.toUTCString()}</pubDate>\n` +
+          `      <content:encoded><![CDATA[${html}]]></content:encoded>\n` +
+          `    </item>`;
+      })
+  );
 
   const rss = `<?xml version="1.0" encoding="UTF-8"?>\n` +
-    `<rss version="2.0">\n` +
+    `<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">\n` +
     `  <channel>\n` +
     `    <title>Twistinside</title>\n` +
     `    <description>Latest articles from Twistinside</description>\n` +
     `    <link>${site}</link>\n` +
-    `    ${items}\n` +
+    `    ${items.join("\n")}\n` +
     `  </channel>\n` +
     `</rss>`;
 


### PR DESCRIPTION
## Summary
- Render full article HTML for RSS items using Astro's experimental container and MDX renderer
- Embed article content in `<content:encoded>` and add RSS namespace

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6220acfc4832bbda23430bb085415