### PR TITLE
Rewrite README with project details and deploy badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,25 @@
-# Astro Starter Kit: Basics
+# Personal Site
 
-```sh
-npm create astro@latest -- --template basics
-```
+[![Deploy Site](https://github.com/twistinside/personal-site/actions/workflows/deploy.yml/badge.svg)](https://github.com/twistinside/personal-site/actions/workflows/deploy.yml)
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/astro/tree/latest/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/astro/tree/latest/examples/basics)
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/withastro/astro?devcontainer_path=.devcontainer/basics/devcontainer.json)
+A simple Astro-powered personal website that highlights projects, shares a bit about me, and links out to the places I’m active online. The goal is to keep the experience fast, accessible, and easy to maintain.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Features
+- Built with [Astro](https://astro.build) for static-first performance.
+- Minimal styling focused on readability and quick loading.
+- Easily extendable content structure for adding new pages or sections.
 
-![just-the-basics](https://github.com/withastro/astro/assets/2244813/a0a5533c-a856-4198-8470-2d67b1d7c554)
+## Getting Started
+1. Install dependencies: `npm install`
+2. Start the local dev server: `npm run dev`
+3. Build for production: `npm run build`
+4. Preview the production build locally: `npm run preview`
 
-## 🚀 Project Structure
+## Project Structure
+Key folders you’ll interact with:
+- `src/pages/`: Individual pages, including the homepage.
+- `src/layouts/`: Shared page layouts and wrappers.
+- `public/`: Static assets that are served as-is.
 
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-│   └── favicon.svg
-├── src/
-│   ├── layouts/
-│   │   └── Layout.astro
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-To learn more about the folder structure of an Astro project, refer to [our guide on project structure](https://docs.astro.build/en/basics/project-structure/).
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `npm install`             | Installs dependencies                            |
-| `npm run dev`             | Starts local dev server at `localhost:4321`      |
-| `npm run build`           | Build your production site to `./dist/`          |
-| `npm run preview`         | Preview your build locally, before deploying     |
-| `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+## Deployment
+The site is automatically built and deployed via GitHub Actions (see the badge above). Push changes to the default branch to trigger a fresh build and deploy.


### PR DESCRIPTION
## Summary
- Replace the starter README with a project-specific description for the personal site
- Document features, setup steps, structure, and deployment information
- Add a GitHub Actions badge for the deploy workflow

## Testing
- Not run (docs-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d2afee50c832bb6396b67589e10e1)